### PR TITLE
ENG-25948: Small improvements

### DIFF
--- a/src/main/java/org/voltdb/meshmonitor/MeshMonitor.java
+++ b/src/main/java/org/voltdb/meshmonitor/MeshMonitor.java
@@ -11,6 +11,7 @@ import org.voltdb.meshmonitor.serdes.IpPortSerializer;
 import org.voltdb.meshmonitor.serdes.PacketSerializer;
 
 import java.io.IOException;
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
@@ -22,8 +23,8 @@ import java.util.concurrent.TimeUnit;
 
 public class MeshMonitor {
 
-    private static final int PROGRAM_ERROR_RESULT = 1;
-    private static final int PROGRAM_SUCCESS_RESULT = 0;
+    public static final int PROGRAM_ERROR_RESULT = 1;
+    public static final int PROGRAM_SUCCESS_RESULT = 0;
 
     private static final ScheduledExecutorService SCHEDULER = Executors.newSingleThreadScheduledExecutor(
             runnable -> {
@@ -63,6 +64,9 @@ public class MeshMonitor {
         try {
             serverSocketChannel = ServerSocketChannel.open();
             serverSocketChannel.socket().bind(bindAddress);
+        } catch (BindException e) {
+            consoleLogger.fatalError(bindAddress.toString(), e);
+            return PROGRAM_ERROR_RESULT;
         } catch (IOException e) {
             consoleLogger.fatalError("Error while opening server socket", e);
             return PROGRAM_ERROR_RESULT;

--- a/src/test/java/org/voltdb/meshmonitor/metrics/SimplePrometheusMetricsServerTest.java
+++ b/src/test/java/org/voltdb/meshmonitor/metrics/SimplePrometheusMetricsServerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.voltdb.meshmonitor.*;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
@@ -34,14 +35,16 @@ class SimplePrometheusMetricsServerTest {
     private static ServerManager serverManager;
 
     @BeforeAll
-    static void setUp() {
+    static void setUp() throws IOException {
         InetSocketAddress address = MonitorTest.address("0.0.0.0");
 
         serverManager = mock(ServerManager.class);
         server = new SimplePrometheusMetricsServer(
                 LOGGER,
                 address,
-                serverManager);
+                "my.book.pro",
+                serverManager
+        );
         server.start();
 
         RestAssured.port = address.getPort();
@@ -105,9 +108,9 @@ class SimplePrometheusMetricsServerTest {
                 .then()
                 .statusCode(200)
                 .body(
-                        containsString("meshmonitor_receive_seconds_bucket{host_name=\"0_0_0_0\",remote_host_name=\"remote_host_com\",le=\"0.005000\"} 1"),
-                        containsString("meshmonitor_delta_seconds_sum{host_name=\"0_0_0_0\",remote_host_name=\"remote_host_com\",} 0"),
-                        containsString("meshmonitor_send_seconds_sum{host_name=\"0_0_0_0\",remote_host_name=\"remote_host_com\",} 0")
+                        containsString("meshmonitor_receive_seconds_bucket{host_name=\"my_book_pro\",remote_host_name=\"remote_host_com\",le=\"0.005000\"} 1"),
+                        containsString("meshmonitor_delta_seconds_sum{host_name=\"my_book_pro\",remote_host_name=\"remote_host_com\",} 0"),
+                        containsString("meshmonitor_send_seconds_sum{host_name=\"my_book_pro\",remote_host_name=\"remote_host_com\",} 0")
                 );
     }
 
@@ -124,14 +127,14 @@ class SimplePrometheusMetricsServerTest {
                 .then()
                 .statusCode(200)
                 .body(
-                        containsString("meshmonitor_receive_seconds_bucket{host_name=\"0_0_0_0\",remote_host_name=\"remote_host_com\",le=\"0.005000\"} 1"),
-                        containsString("meshmonitor_delta_seconds_sum{host_name=\"0_0_0_0\",remote_host_name=\"remote_host_com\",} 0"),
-                        containsString("meshmonitor_send_seconds_sum{host_name=\"0_0_0_0\",remote_host_name=\"remote_host_com\",} 0"),
+                        containsString("meshmonitor_receive_seconds_bucket{host_name=\"my_book_pro\",remote_host_name=\"remote_host_com\",le=\"0.005000\"} 1"),
+                        containsString("meshmonitor_delta_seconds_sum{host_name=\"my_book_pro\",remote_host_name=\"remote_host_com\",} 0"),
+                        containsString("meshmonitor_send_seconds_sum{host_name=\"my_book_pro\",remote_host_name=\"remote_host_com\",} 0"),
 
-                        containsString("meshmonitor_receive_seconds_bucket{host_name=\"0_0_0_0\",remote_host_name=\"other_host_com\",le=\"0.005000\"} 0"),
-                        containsString("meshmonitor_receive_seconds_bucket{host_name=\"0_0_0_0\",remote_host_name=\"other_host_com\",le=\"0.050000\"} 1"),
-                        containsString("meshmonitor_delta_seconds_sum{host_name=\"0_0_0_0\",remote_host_name=\"other_host_com\",} 0"),
-                        containsString("meshmonitor_send_seconds_sum{host_name=\"0_0_0_0\",remote_host_name=\"other_host_com\",} 0")
+                        containsString("meshmonitor_receive_seconds_bucket{host_name=\"my_book_pro\",remote_host_name=\"other_host_com\",le=\"0.005000\"} 0"),
+                        containsString("meshmonitor_receive_seconds_bucket{host_name=\"my_book_pro\",remote_host_name=\"other_host_com\",le=\"0.050000\"} 1"),
+                        containsString("meshmonitor_delta_seconds_sum{host_name=\"my_book_pro\",remote_host_name=\"other_host_com\",} 0"),
+                        containsString("meshmonitor_send_seconds_sum{host_name=\"my_book_pro\",remote_host_name=\"other_host_com\",} 0")
                 );
     }
 


### PR DESCRIPTION
- Added descriptive message when port conflict occurs (instead of stacktrace). 
- Prometheus output includes more useful host name as `host_name` label, e.g. `tomaszs-mbp-2_localdomain` instead of `localhost`. 
- Logging of errors that could happen during Prometheus response generation.