### PR TITLE
Always run license:check before compile. Update some copyright dates where needed.

### DIFF
--- a/docker/meshmonitor.dockerfile
+++ b/docker/meshmonitor.dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Volt Active Data Inc.
+# Copyright (C) 2024-2025 Volt Active Data Inc.
 #
 # Use of this source code is governed by an MIT
 # license that can be found in the LICENSE file or at

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,8 @@
                 </dependencies>
                 <executions>
                     <execution>
+                        <id>check-license</id>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/src/main/java/org/voltdb/meshmonitor/ConsoleLogger.java
+++ b/src/main/java/org/voltdb/meshmonitor/ConsoleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/main/java/org/voltdb/meshmonitor/GitPropertiesVersionProvider.java
+++ b/src/main/java/org/voltdb/meshmonitor/GitPropertiesVersionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/main/java/org/voltdb/meshmonitor/ServerManager.java
+++ b/src/main/java/org/voltdb/meshmonitor/ServerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/main/java/org/voltdb/meshmonitor/metrics/MonitorStatsPrinter.java
+++ b/src/main/java/org/voltdb/meshmonitor/metrics/MonitorStatsPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/GitPropertiesVersionProviderTest.java
+++ b/src/test/java/org/voltdb/meshmonitor/GitPropertiesVersionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/HistogramLoggerTest.java
+++ b/src/test/java/org/voltdb/meshmonitor/HistogramLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/MeshMonitorTimingsTest.java
+++ b/src/test/java/org/voltdb/meshmonitor/MeshMonitorTimingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/metrics/HistogramPrinterTest.java
+++ b/src/test/java/org/voltdb/meshmonitor/metrics/HistogramPrinterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/metrics/MonitorStatsPrinterTest.java
+++ b/src/test/java/org/voltdb/meshmonitor/metrics/MonitorStatsPrinterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/metrics/SimplePrometheusMetricsServerTest.java
+++ b/src/test/java/org/voltdb/meshmonitor/metrics/SimplePrometheusMetricsServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/testutils/ByteBufferReadableByteChannel.java
+++ b/src/test/java/org/voltdb/meshmonitor/testutils/ByteBufferReadableByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/testutils/FakeWritableByteChannel.java
+++ b/src/test/java/org/voltdb/meshmonitor/testutils/FakeWritableByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/testutils/FileChannelUtils.java
+++ b/src/test/java/org/voltdb/meshmonitor/testutils/FileChannelUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Volt Active Data Inc.
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
  *
  * Use of this source code is governed by an MIT
  * license that can be found in the LICENSE file or at

--- a/src/test/java/org/voltdb/meshmonitor/testutils/FileChannelUtilsTest.java
+++ b/src/test/java/org/voltdb/meshmonitor/testutils/FileChannelUtilsTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2024-2025 Volt Active Data Inc.
+ *
+ * Use of this source code is governed by an MIT
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
 package org.voltdb.meshmonitor.testutils;
 
 import org.junit.Test;


### PR DESCRIPTION
This fixes missing copyright updates for files changed in 2025, so that license:check passes.